### PR TITLE
✨ feat(feed): add sorting by date

### DIFF
--- a/doteki/plugins/feed.py
+++ b/doteki/plugins/feed.py
@@ -1,6 +1,6 @@
 import logging
 from datetime import datetime
-from typing import Any
+from typing import Any, Optional
 
 import feedparser
 import requests
@@ -8,6 +8,7 @@ import requests
 DEFAULT_DATE_FORMAT = "%Y-%m-%d"
 DEFAULT_N = 5
 DEFAULT_SEPARATOR = "·"
+DEFAULT_SORT_FIELD = "published"
 
 
 def run(settings: dict[str, Any]) -> str | list[str] | None:
@@ -39,33 +40,50 @@ def run(settings: dict[str, Any]) -> str | list[str] | None:
     show_date = settings.get("show_date", False)
     separator = settings.get("separator", DEFAULT_SEPARATOR)
     n = settings.get("n", DEFAULT_N)
-    entries = feed.entries[:n]
+    sort_field = settings.get("sort_field", DEFAULT_SORT_FIELD)
+
+    entries = feed.entries
+    if "sort_order" in settings:
+        entries = sort_entries(entries, sort_field, settings["sort_order"])
+
+    entries = entries[:n]
     formatted_entries = [
-        format_entry(entry, separator, date_format, show_date) for entry in entries
+        format_entry(entry, separator, date_format, show_date, sort_field)
+        for entry in entries
     ]
     return formatted_entries if n != 1 else formatted_entries[0]
 
 
 def validate_settings(settings: dict[str, Any]) -> bool:
     expected_types = {
-        "url": str,  # Required.
-        "n": int,  # Optional.
-        "show_date": bool,  # Optional.
-        "separator": str,  # Optional.
-        "date_format": str,  # Optional.
+        "url": str,  # Required
+        "n": int,  # Optional
+        "show_date": bool,  # Optional
+        "separator": str,  # Optional
+        "date_format": str,  # Optional
+        "sort_order": str,  # Optional
+        "sort_field": str,  # Optional
     }
+    valid_sort_orders = {"ascending", "descending"}
+    valid_sort_fields = {"published", "updated"}
     errors = []
-
-    # Check required setting.
     if "url" not in settings:
         errors.append("No url provided for the Feed plugin")
-
-    # Validate types of provided settings.
     for setting, value in settings.items():
         expected_type = expected_types.get(setting)
         if expected_type and not isinstance(value, expected_type):
             errors.append(
                 f"Invalid type for {setting}: '{type(value).__name__}'. Expected {expected_type.__name__}"
+            )
+
+        if setting == "sort_order" and value not in valid_sort_orders:
+            errors.append(
+                f"Invalid sort_order: '{value}'. Must be one of {valid_sort_orders}"
+            )
+
+        if setting == "sort_field" and value not in valid_sort_fields:
+            errors.append(
+                f"Invalid sort_field: '{value}'. Must be one of {valid_sort_fields}"
             )
 
     if errors:
@@ -76,12 +94,37 @@ def validate_settings(settings: dict[str, Any]) -> bool:
     return True
 
 
+def sort_entries(entries: list, sort_field: str, sort_order: str) -> list:
+    def get_sort_key(entry):
+        date_tuple = get_entry_date(entry, sort_field)
+        if date_tuple:
+            return datetime(*date_tuple[:6])
+        # Entries without dates at the end.
+        return datetime.min if sort_order == "descending" else datetime.max
+
+    reverse = sort_order == "descending"
+    return sorted(entries, key=get_sort_key, reverse=reverse)
+
+
+def get_entry_date(entry: dict[str, Any], field: str) -> Optional[tuple]:
+    primary_field = f"{field}_parsed"
+    fallback_field = "published_parsed" if field == "updated" else "updated_parsed"
+    date_tuple = entry.get(primary_field)
+    if date_tuple is None:
+        date_tuple = entry.get(fallback_field)
+    return date_tuple
+
+
 def format_entry(
-    entry: dict[str, Any], separator: str, date_format: str, show_date: bool
+    entry: dict[str, Any],
+    separator: str,
+    date_format: str,
+    show_date: bool,
+    sort_field: str = "published",
 ) -> str:
     title = get_entry_data(entry, "title", "No Title")
     link = get_entry_data(entry, "link", "")
-    date_str = get_formatted_date(entry, date_format, show_date)
+    date_str = get_formatted_date(entry, date_format, show_date, sort_field)
 
     separator_str = f" {separator} " if date_str else ""
     return f"[{title}]({link}){separator_str}{date_str}"
@@ -95,12 +138,16 @@ def get_entry_data(entry: dict[str, Any], key: str, default: str) -> str:
         return default
 
 
-def get_formatted_date(entry: dict[str, Any], date_format: str, show_date: bool) -> str:
-    date_tuple = entry.get("published_parsed")
-    if show_date and date_tuple:
-        # Unpacks first six elements (year, month, day, hour, minute, second)
-        # and formats them into a string.
+def get_formatted_date(
+    entry: dict[str, Any],
+    date_format: str,
+    show_date: bool,
+    sort_field: str = "published",
+) -> str:
+    if not show_date:
+        return ""
+    date_tuple = get_entry_date(entry, sort_field)
+    if date_tuple:
         return datetime(*date_tuple[:6]).strftime(date_format)
-    elif show_date:
-        logging.warning("Entry missing date")
+    logging.warning("Entry missing date")
     return ""

--- a/doteki/plugins/feed.py
+++ b/doteki/plugins/feed.py
@@ -9,6 +9,7 @@ DEFAULT_DATE_FORMAT = "%Y-%m-%d"
 DEFAULT_N = 5
 DEFAULT_SEPARATOR = "·"
 DEFAULT_SORT_FIELD = "published"
+DEFAULT_SORT_ORDER = "descending"  # Only used if sort_field is set.
 
 
 def run(settings: dict[str, Any]) -> str | list[str] | None:
@@ -43,8 +44,9 @@ def run(settings: dict[str, Any]) -> str | list[str] | None:
     sort_field = settings.get("sort_field", DEFAULT_SORT_FIELD)
 
     entries = feed.entries
-    if "sort_order" in settings:
-        entries = sort_entries(entries, sort_field, settings["sort_order"])
+    if sort_field := settings.get("sort_field"):
+        sort_order = settings.get("sort_order", DEFAULT_SORT_ORDER)
+        entries = sort_entries(entries, sort_field, sort_order)
 
     entries = entries[:n]
     formatted_entries = [

--- a/tests/plugins/test_feed.py
+++ b/tests/plugins/test_feed.py
@@ -297,6 +297,9 @@ MOCK_FEED_WITH_MISSING_DATA = b"""
 """
 
 
+@pytest.mark.filterwarnings(
+    "ignore:To avoid breaking existing software:DeprecationWarning"
+)
 @patch("requests.get")
 def test_feed_with_missing_data(mock_get, caplog):
     # Mock response with the feed having an entry missing a title
@@ -353,6 +356,9 @@ MOCK_FEED_MISSING_DATE = b"""
 """
 
 
+@pytest.mark.filterwarnings(
+    "ignore:To avoid breaking existing software:DeprecationWarning"
+)
 @patch("requests.get")
 def test_feed_missing_date(mock_get, caplog):
     mock_response = MagicMock()

--- a/tests/plugins/test_feed.py
+++ b/tests/plugins/test_feed.py
@@ -386,3 +386,220 @@ def test_n_one_returns_str(mock_get):
     expected_output = "[Entry w/ date](http://example.com/entry1)"
     assert result == expected_output
     assert isinstance(result, str)
+
+
+@patch("requests.get")
+def test_sort_by_published_date(mock_get):
+    mock_response = MagicMock()
+    mock_response.content = MOCK_ATOM_FEED_XML
+    mock_response.raise_for_status = MagicMock()
+    mock_get.return_value = mock_response
+
+    # Test ascending order
+    settings = {
+        "url": "https://example.com/atom.xml",
+        "sort_order": "ascending",
+        "sort_field": "published",
+    }
+    result = run(settings)
+    assert result[0].startswith("[Artificial Intelligence Ethics")  # Oldest
+    assert result[-1].startswith("[Understanding Machine Learning")  # Newest
+
+    # Test descending order
+    settings["sort_order"] = "descending"
+    result = run(settings)
+    assert result[0].startswith("[Understanding Machine Learning")  # Newest
+    assert result[-1].startswith("[Artificial Intelligence Ethics")  # Oldest
+
+
+@patch("requests.get")
+def test_sort_by_updated_date(mock_get):
+    mock_response = MagicMock()
+    mock_response.content = MOCK_ATOM_FEED_XML
+    mock_response.raise_for_status = MagicMock()
+    mock_get.return_value = mock_response
+
+    settings = {
+        "url": "https://example.com/atom.xml",
+        "sort_order": "descending",
+        "sort_field": "updated",
+    }
+    result = run(settings)
+    assert result[0].startswith("[Understanding Machine Learning")  # Last updated
+    assert result[-1].startswith("[Artificial Intelligence Ethics")  # First updated
+
+
+MOCK_FEED_MIXED_DATES = b"""
+<feed>
+    <entry>
+        <title>Entry 1</title>
+        <link href="http://example.com/entry1" />
+        <published>2024-01-01T00:00:00Z</published>
+        <updated>2024-01-02T00:00:00Z</updated>
+    </entry>
+    <entry>
+        <title>Entry 2</title>
+        <link href="http://example.com/entry2" />
+        <published>2024-01-02T00:00:00Z</published>
+    </entry>
+    <entry>
+        <title>Entry 3</title>
+        <link href="http://example.com/entry3" />
+        <published>2024-01-03T00:00:00Z</published>
+        <updated>2024-01-01T00:00:00Z</updated>
+    </entry>
+</feed>
+"""
+
+
+@pytest.mark.filterwarnings(
+    "ignore:To avoid breaking existing software:DeprecationWarning"
+)
+@patch("requests.get")
+def test_sort_with_mixed_dates(mock_get):
+    mock_response = MagicMock()
+    mock_response.content = MOCK_FEED_MIXED_DATES
+    mock_response.raise_for_status = MagicMock()
+    mock_get.return_value = mock_response
+
+    # Test sorting by updated - the order should be:
+    # Entry 3 (Jan 1), Entry 1 (Jan 2), Entry 2 (falls back to published date Jan 2)
+    settings = {
+        "url": "https://example.com/atom.xml",
+        "sort_order": "ascending",
+        "sort_field": "updated",
+    }
+    result = run(settings)
+
+    assert len(result) == 3
+    assert result[0].startswith("[Entry 3")  # Updated Jan 1
+    assert result[1].startswith("[Entry 1")  # Updated Jan 2
+    # Entry 2 should be last, using its published date as fallback
+    assert result[2].startswith("[Entry 2")
+
+
+def test_invalid_sort_parameters(caplog):
+    settings = {
+        "url": "https://example.com/atom.xml",
+        "sort_order": "invalid",
+        "sort_field": "published",
+    }
+    with caplog.at_level(logging.ERROR):
+        result = run(settings)
+    assert result is None
+    assert "Invalid sort_order: 'invalid'" in caplog.text
+
+    settings = {
+        "url": "https://example.com/atom.xml",
+        "sort_order": "ascending",
+        "sort_field": "invalid",
+    }
+    with caplog.at_level(logging.ERROR):
+        result = run(settings)
+    assert result is None
+    assert "Invalid sort_field: 'invalid'" in caplog.text
+
+
+MOCK_FEED_UPDATED_FALLBACK = b"""
+<feed>
+    <entry>
+        <title>Entry 1</title>
+        <link href="http://example.com/entry1" />
+        <published>2024-01-01T00:00:00Z</published>
+        <updated>2024-01-03T00:00:00Z</updated>
+    </entry>
+    <entry>
+        <title>Entry 2</title>
+        <link href="http://example.com/entry2" />
+        <published>2024-01-02T00:00:00Z</published>
+    </entry>
+    <entry>
+        <title>Entry 3</title>
+        <link href="http://example.com/entry3" />
+        <published>2024-01-03T00:00:00Z</published>
+        <updated>2024-01-01T00:00:00Z</updated>
+    </entry>
+</feed>
+"""
+
+
+@pytest.mark.filterwarnings(
+    "ignore:To avoid breaking existing software:DeprecationWarning"
+)
+@patch("requests.get")
+def test_sort_updated_fallback(mock_get):
+    mock_response = MagicMock()
+    mock_response.content = MOCK_FEED_UPDATED_FALLBACK
+    mock_response.raise_for_status = MagicMock()
+    mock_get.return_value = mock_response
+
+    settings = {
+        "url": "https://example.com/atom.xml",
+        "sort_order": "ascending",
+        "sort_field": "updated",
+    }
+    result = run(settings)
+
+    # In ascending order:
+    # Entry 3 (updated Jan 1)
+    # Entry 2 (no updated, published Jan 2)
+    # Entry 1 (updated Jan 3)
+    assert len(result) == 3
+    assert result[0].startswith("[Entry 3")  # Updated earliest
+    assert result[1].startswith("[Entry 2")  # Uses published date as fallback
+    assert result[2].startswith("[Entry 1")  # Updated latest
+
+    # Test descending order too
+    settings["sort_order"] = "descending"
+    result = run(settings)
+    assert result[0].startswith("[Entry 1")  # Updated latest
+    assert result[1].startswith("[Entry 2")  # Uses published date as fallback
+    assert result[2].startswith("[Entry 3")  # Updated earliest
+
+
+MOCK_FEED_NO_DATES = b"""
+<feed>
+    <entry>
+        <title>Entry 1</title>
+        <link href="http://example.com/entry1" />
+        <published>2024-01-01T00:00:00Z</published>
+    </entry>
+    <entry>
+        <title>Entry 2</title>
+        <link href="http://example.com/entry2" />
+    </entry>
+    <entry>
+        <title>Entry 3</title>
+        <link href="http://example.com/entry3" />
+        <published>2024-01-03T00:00:00Z</published>
+    </entry>
+</feed>
+"""
+
+
+@patch("requests.get")
+def test_sort_with_missing_all_dates(mock_get, caplog):
+    mock_response = MagicMock()
+    mock_response.content = MOCK_FEED_NO_DATES
+    mock_response.raise_for_status = MagicMock()
+    mock_get.return_value = mock_response
+
+    # Test ascending order - dateless entries should be at the end.
+    settings = {
+        "url": "https://example.com/atom.xml",
+        "sort_order": "ascending",
+        "sort_field": "published",
+    }
+    result = run(settings)
+
+    assert len(result) == 3
+    assert result[0].startswith("[Entry 1")  # Jan 1
+    assert result[1].startswith("[Entry 3")  # Jan 3
+    assert result[2].startswith("[Entry 2")  # No date -> should be last in ascending
+
+    # Test descending order - dateless entries should still be at the end.
+    settings["sort_order"] = "descending"
+    result = run(settings)
+    assert result[0].startswith("[Entry 3")  # Jan 3
+    assert result[1].startswith("[Entry 1")  # Jan 1
+    assert result[2].startswith("[Entry 2")  # No date -> should be last in descending

--- a/website/docs/plugins/feed.mdx
+++ b/website/docs/plugins/feed.mdx
@@ -17,8 +17,10 @@ The Feed plugin can be customized with several settings:
 - `url` (required): The URL of the RSS or Atom feed.
 - `n`: The number of feed items to display. Default: `5`.
 - `date_format`: The format for displaying dates. Default: `"%Y-%m-%d"`, which displays dates as `YYYY-MM-DD`.
-- `show_date`: A boolean to indicate whether to show the publication date of each feed item. Default: `False`.
+- `show_date`: A boolean to indicate whether to show the publication/update date of each feed item. Default: `False`.
 - `separator`: The separator character to use when displaying dates. Default: `"·"`.
+- `sort_order`: Optional sorting direction: `"ascending"` or `"descending"`. Default: No sorting (keeps feed order).
+- `sort_field`: Which date field to sort by: `"published"` or `"updated"`. Default: `"published"`. If sorting by `"updated"` and an entry lacks an update date, falls back to using its published date.
 
 ## Usage
 


### PR DESCRIPTION
## Summary

Add optional sorting capabilities to the Feed plugin:
- New `sort_order` setting ("ascending"/"descending")
- New `sort_field` setting ("published"/"updated"). Optional. Defaults to published
- Fallback to published date when updated date missing
- Default behavior preserves original feed order

---

### How has this been tested?

- [ ] Manual tests
- [X] Unit tests
- [ ] Integration tests

---

### Type of change

- [ ] Bug fix (fixes an issue without altering functionality)
- [X] New feature (adds non-breaking functionality)
- [ ] Breaking change (alters existing functionality)
- [ ] UI/UX improvement (enhances user interface without altering functionality)
- [ ] Refactor (improves code quality without altering functionality)
- [ ] Documentation update
- [ ] Other (please describe below)

---

### Checklist

- [x] I have read the [**contributing guidelines**](https://github.com/welpo/doteki/blob/main/CONTRIBUTING.md).
- [x] I have formatted the code with [Black](https://github.com/psf/black).
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.